### PR TITLE
workaround namespace collision with docker-py and enable Debian support

### DIFF
--- a/cvmfs-singularity-sync
+++ b/cvmfs-singularity-sync
@@ -30,11 +30,24 @@ perform publicly and display publicly, and to permit other to do so.
 '''
 
 import sys
-if '/usr/libexec/singularity/python' not in sys.path:
-    sys.path.append('/usr/libexec/singularity/python')
+import platform
+
+# enable cross-platform/multi-distro support by setting singularity_path
+# to appropriate location or to None
+singularity_path = None
+if platform.system() == 'Linux':
+    distro,version,id = platform.linux_distribution(full_distribution_name=False)
+    if distro == 'debian':
+        singularity_path = '/usr/lib/x86_64-linux-gnu/singularity/python'
+    elif distro == 'redhat':
+        singularity_path = '/usr/libexec/singularity/python'
+
+if singularity_path not in sys.path and singularity_path is not None:
+    sys.path.insert(0,singularity_path)
 
 from docker.api import get_layer, create_runscript, get_manifest, get_config, get_images, get_tags
 from utils import extract_tar, change_permissions
+
 import argparse
 import os
 import re


### PR DESCRIPTION
1. Prepend to sys.path rather than append because there is namespace collision between singularity Docker library and docker-py
2. Enable cross-platform/multi-distro support for finding Singularity libraries