### PR TITLE
Add RHEL7-derived image of LIGO execute node

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -63,6 +63,7 @@ cyverse/rsem-prepare
 # LIGO worker node
 ligo/software:jessie
 ligo/software:jessie-proposed
+ligo/software:el7
 
 # LIGO PyCBC compute nodes
 pycbc/pycbc-el7:v*


### PR DESCRIPTION
LIGO now has a DockerHub image of its RHEL7 execute nodes. Please mirror it on singularity.opensciencegrid.org.