### PR TITLE
Mats docker hub images no longer exist

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -43,8 +43,6 @@ opensciencegrid/osgvo:el6
 opensciencegrid/osgvo:el7
 opensciencegrid/tensorflow
 opensciencegrid/tensorflow-gpu
-rynge/osgvo:el6
-rynge/osgvo:el7
 rynge/einsteintoolkit:latest
 rynge/osg-tensorflow-gpu:latest
 


### PR DESCRIPTION
I believe he moved them to the OSG org.

It was breaking the sync.