### PR TITLE
docker_images.txt: Update for Argonne EIC software tags

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -60,7 +60,8 @@ alpine
 
 # Electron Ion Collider images
 whit2333/eic-slic:latest
-argonneeic/fpadsim:flat
+argonneeic/evochain:v*
+argonneeic/fpadsim:v*
 
 # Common biology tools
 biocontainers/blast


### PR DESCRIPTION
Another Argonne EIC docker tag update.

Old images from docker://dbcooper/fpadsim:singularity and docker://argonneeic/fpadsim:flat are no longer needed and can be removed from cvmfs.