### PR TITLE
add ucatlas/xah docker image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -92,6 +92,9 @@ lincolnbryant/atlas-wn
 atlas/analysisbase:21.2.4
 atlas/athanalysis:21.2.4
 
+# ATLAS image with xAODAnaHelpers framework
+#  version should follow above ATLAS standalone images
+ucatlas/xah:21.2.4-latest
 
 # Gluex worker node
 rjones30/gluex


### PR DESCRIPTION
This adds the [xAODAnaHelpers docker images](https://github.com/UCATLAS/xAODAnaHelpers) built on top of the analysisbase images added in #35 .

I assume these images get resynced on a periodic basis (cron job perhaps) as `ucatlas/xah:21.2.4-latest` will always point to the latest push for the given release (`21.2.4`).

ATLAS user: gstark (my username backwards)