### PR TITLE
Adding CUDA el6 image for CMS

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -80,6 +80,7 @@ pycbc/pycbc-el7:latest
 # CMS worker node
 bbockelm/cms:rhel6
 bbockelm/cms:rhel7
+efajardo/docker-cms:cuda
 
 # ATLAS worker node
 lincolnbryant/atlas-wn


### PR DESCRIPTION
CMS is now ready to run in GPUS and in the CMSSW is packing some ML like theanos that can run in EL6. They needed a singularity images with the cuda libraries installed.