### PR TITLE
added discoenv/osg-word-count

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -129,4 +129,5 @@ evolinc/rmta:1.6
 evolinc/evolinc-i:1.6
 dajunluo/deepvariant
 
-
+# Images for Testing the Integration Between the CyVerse Discovery Environment and OSG
+discoenv/osg-word-count:1.0.0


### PR DESCRIPTION
This image is going to be used to test the integration between OSG and the CyVerse Discovery Environment.
