### PR TITLE
Added CMS workernode images with hadoop

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -113,6 +113,9 @@ pycbc/pycbc-el7:latest
 bbockelm/cms:rhel6
 bbockelm/cms:rhel7
 efajardo/docker-cms:tensorflow
+# CMS worker node with hadoop
+kreczko/workernode:centos6
+kreczko/workernode:centos7
 
 # ATLAS worker node
 lincolnbryant/atlas-wn


### PR DESCRIPTION
This is expanding on the work from @bbockelm and @alahiff to include a hadoop-client installation.
While the previous images work well for grid, our local users do also need to access the HDFS storage directly to copy output files across.
