### PR TITLE
Added docker image for CLAS12 simulations

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -153,3 +153,6 @@ dajunluo/deepvariant
 # Images for Testing the Integration Between the CyVerse Discovery Environment and OSG
 discoenv/osg-word-count:1.0.0
 cyverse/osg-gl:1.0
+
+# JLab CLAS12 Simulations
+maureeungaro/clas12simulations:production


### PR DESCRIPTION
The docker image:

maureeungaro/clas12simulations:production

is an automated build on hub.docker. It is used to run Monte-Carlo simulation of the CLAS12 detector at Jefferson Lab.