### PR TITLE
Add cleanup based on Derek's PR

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -13,6 +13,7 @@ import json
 import datetime
 import dateutil.parser
 import shutil
+import argparse
 
 json_location = "/cvmfs/singularity.opensciencegrid.org/.missing_links.json"
 #json_location = "missing_links.json"
@@ -25,8 +26,8 @@ json_location = "/cvmfs/singularity.opensciencegrid.org/.missing_links.json"
 #   }
 # }
 
-def cleanup(delay=2):
-
+def cleanup(delay=2, test=False):
+    '''Clean up unlinked singularity images'''
     # Read in the old json, if it exists
     json_missing_links = {}
     if os.path.exists(json_location):
@@ -65,8 +66,9 @@ def cleanup(delay=2):
         if date_last_linked < (datetime.datetime.now() - datetime.timedelta(days=delay)):
             # Remove the directory
             print("Removing missing link: %s" % image_dir)
-            shutil.rmtree(image_dir)
-            del json_missing_links[image_dir]
+            if not test:
+                shutil.rmtree(image_dir)
+                del json_missing_links[image_dir]
 
     # Write out the end json
     with open(json_location, 'w') as json_file:
@@ -75,9 +77,17 @@ def cleanup(delay=2):
 
 
 def main():
+    '''Main function'''
+    args = parse_args()
+    cleanup(test=args.test)
 
-    cleanup()
+def parse_args():
+    '''Parse CLI options'''
+    parser = argparse.ArgumentParser()
 
+    parser.add_argument('--test', action='store_true',
+                        help="Don't remove files, but go through the motions of removing them.")
+    return parser.parse_args()
 
 if __name__ == "__main__":
     main()

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Cleanup for Singularity container
 

--- a/cleanup.py
+++ b/cleanup.py
@@ -26,21 +26,21 @@ json_location = "/cvmfs/singularity.opensciencegrid.org/.missing_links.json"
 # }
 
 def cleanup(delay=2):
-    
+
     # Read in the old json, if it exists
     json_missing_links = {}
     if os.path.exists(json_location):
         with open(json_location) as json_file:
             json_missing_links = json.loads(json_file.read())['missing_links']
-    
+
     # Get all the images in the repo
-    
+
     # Walk the directory /cvmfs/singularity.opensciencegrid.org/.images/*
     image_dirs = glob.glob("/cvmfs/singularity.opensciencegrid.org/.images/*/*")
-    
+
     # Walk the named image dirs
     named_image_dir = glob.glob("/cvmfs/singularity.opensciencegrid.org/*/*")
-    
+
     # For named image dir, look at the what the symlink points at 
     for named_image in named_image_dir:
         link_target = os.readlink(named_image)
@@ -49,7 +49,7 @@ def cleanup(delay=2):
             print "%s not in list of image directories from %s" % (link_target, named_image)
         else:
             image_dirs.remove(link_target)
-    
+
     # Now, for each image, see if it's in the json
     for image_dir in image_dirs:
         if image_dir in json_missing_links:
@@ -58,7 +58,7 @@ def cleanup(delay=2):
             # Add it to the json
             print "Newly found missing link: %s" % (image_dir)
             json_missing_links[image_dir] = str(datetime.datetime.now())
-    
+
     # Loop through the json missing links, removing directories if over the `delay` days
     for image_dir, last_linked in json_missing_links.items():
         date_last_linked = dateutil.parser.parse(last_linked)
@@ -67,15 +67,15 @@ def cleanup(delay=2):
             print "Removing missing link: %s" % image_dir
             shutil.rmtree(image_dir)
             del json_missing_links[image_dir]
-    
+
     # Write out the end json
     with open(json_location, 'w') as json_file:
         json_file.write(json.dumps({"missing_links": json_missing_links}, default=str))
-    
+
 
 
 def main():
-    
+
     cleanup()
 
 

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,0 +1,83 @@
+"""
+Cleanup for Singularity container
+
+Scan the images in the singularity CVMFS.  If an image directory has not been "linked" to for 2 days, 
+remove the image directory.
+
+Maintains state in a file in the root singularity directory named .missing_links.json
+
+"""
+import glob
+import os
+import json
+import datetime
+import dateutil.parser
+import shutil
+
+json_location = "/cvmfs/singularity.opensciencegrid.org/.missing_links.json"
+#json_location = "missing_links.json"
+
+# JSON structure:
+# {
+#   "missing_links": {
+#       "/cvmfs/singularity.opensciencegrid.org/.images/7d/ba009871baa50e01d655a80f79728800401bbd0f5e7e18b5055839e713c09f": "<timestamp_last_linked>"
+#       ...
+#   }
+# }
+
+def cleanup(delay=2):
+    
+    # Read in the old json, if it exists
+    json_missing_links = {}
+    if os.path.exists(json_location):
+        with open(json_location) as json_file:
+            json_missing_links = json.loads(json_file.read())['missing_links']
+    
+    # Get all the images in the repo
+    
+    # Walk the directory /cvmfs/singularity.opensciencegrid.org/.images/*
+    image_dirs = glob.glob("/cvmfs/singularity.opensciencegrid.org/.images/*/*")
+    
+    # Walk the named image dirs
+    named_image_dir = glob.glob("/cvmfs/singularity.opensciencegrid.org/*/*")
+    
+    # For named image dir, look at the what the symlink points at 
+    for named_image in named_image_dir:
+        link_target = os.readlink(named_image)
+        # Multiple images can point to the same image_dir
+        if link_target not in image_dirs:
+            print "%s not in list of image directories from %s" % (link_target, named_image)
+        else:
+            image_dirs.remove(link_target)
+    
+    # Now, for each image, see if it's in the json
+    for image_dir in image_dirs:
+        if image_dir in json_missing_links:
+            image_dirs.remove(image_dir)
+        else:
+            # Add it to the json
+            print "Newly found missing link: %s" % (image_dir)
+            json_missing_links[image_dir] = str(datetime.datetime.now())
+    
+    # Loop through the json missing links, removing directories if over the `delay` days
+    for image_dir, last_linked in json_missing_links.items():
+        date_last_linked = dateutil.parser.parse(last_linked)
+        if date_last_linked < (datetime.datetime.now() - datetime.timedelta(days=delay)):
+            # Remove the directory
+            print "Removing missing link: %s" % image_dir
+            shutil.rmtree(image_dir)
+            del json_missing_links[image_dir]
+    
+    # Write out the end json
+    with open(json_location, 'w') as json_file:
+        json_file.write(json.dumps({"missing_links": json_missing_links}, default=str))
+    
+
+
+def main():
+    
+    cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/cleanup.py
+++ b/cleanup.py
@@ -10,10 +10,10 @@ Maintains state in a file in the root singularity directory named .missing_links
 import glob
 import os
 import json
-import datetime
-import dateutil.parser
 import shutil
 import argparse
+import time
+from datetime import datetime, timedelta
 
 SINGULARITY_BASE = '/cvmfs/singularity.opensciencegrid.org'
 
@@ -63,12 +63,13 @@ def cleanup(delay=2, test=False):
         else:
             # Add it to the json
             print("Newly found missing link: %s" % (image_dir))
-            json_missing_links[image_dir] = str(datetime.datetime.now())
+            json_missing_links[image_dir] = int(time.time())
 
     # Loop through the json missing links, removing directories if over the `delay` days
+    expiry = datetime.now() - timedelta(days=delay)
     for image_dir, last_linked in json_missing_links.items():
-        date_last_linked = dateutil.parser.parse(last_linked)
-        if date_last_linked < (datetime.datetime.now() - datetime.timedelta(days=delay)):
+        date_last_linked = datetime.fromtimestamp(last_linked)
+        if date_last_linked < expiry:
             # Remove the directory
             print("Removing missing link: %s" % image_dir)
             if not test:

--- a/cleanup.py
+++ b/cleanup.py
@@ -46,7 +46,7 @@ def cleanup(delay=2):
         link_target = os.readlink(named_image)
         # Multiple images can point to the same image_dir
         if link_target not in image_dirs:
-            print "%s not in list of image directories from %s" % (link_target, named_image)
+            print("%s not in list of image directories from %s" % (link_target, named_image))
         else:
             image_dirs.remove(link_target)
 
@@ -56,7 +56,7 @@ def cleanup(delay=2):
             image_dirs.remove(image_dir)
         else:
             # Add it to the json
-            print "Newly found missing link: %s" % (image_dir)
+            print("Newly found missing link: %s" % (image_dir))
             json_missing_links[image_dir] = str(datetime.datetime.now())
 
     # Loop through the json missing links, removing directories if over the `delay` days
@@ -64,7 +64,7 @@ def cleanup(delay=2):
         date_last_linked = dateutil.parser.parse(last_linked)
         if date_last_linked < (datetime.datetime.now() - datetime.timedelta(days=delay)):
             # Remove the directory
-            print "Removing missing link: %s" % image_dir
+            print("Removing missing link: %s" % image_dir)
             shutil.rmtree(image_dir)
             del json_missing_links[image_dir]
 

--- a/cvmfs-singularity-sync
+++ b/cvmfs-singularity-sync
@@ -43,6 +43,7 @@ import urllib2
 import hashlib
 import tempfile
 import tarfile
+import cleanup
 
 def main():
     parser = argparse.ArgumentParser(description="Bootstrap Docker images for Singularity containers deployed to CVMFS")
@@ -129,6 +130,7 @@ def main():
                 if retval:
                     final_retval = retval
         print "All requested images have been attempted; final return code: %d" % final_retval
+        cleanup.cleanup()
         return final_retval
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 docker==2.0.0
 furl
 requests
+python-dateutil
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 docker==2.0.0
 furl
 requests
-python-dateutil
-


### PR DESCRIPTION
Derek's cleanup script from #91 with a few additional changes:
- Use Python 3 print() style
- Add `--test` flag for dry-runs
- Use datetime instead of dateutil (built-in module)
- Additional safety checks
    - Confirm we're inside the managed directory before unlinking
    - Handle the case where a link is restored to an image
