### PR TITLE
Wrap cleanup in start_txn() and publish_txn() calls

### DIFF
--- a/cvmfs-singularity-sync
+++ b/cvmfs-singularity-sync
@@ -136,7 +136,10 @@ def main():
                 if retval:
                     final_retval = retval
         print "All requested images have been attempted; final return code: %d" % final_retval
+        print "Cleaning up unlinked images"
+        start_txn(singularity_rootfs)
         cleanup.cleanup(singularity_base=singularity_rootfs)
+        publish_txn()
         return final_retval
 
 


### PR DESCRIPTION
Making the repo read/write for cleanup requires start_txn() and publish_txn() calls