### PR TITLE
add SLC5-based image for CMS

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -121,6 +121,7 @@ efajardo/docker-cms:tensorflow
 # CMS worker node with hadoop
 kreczko/workernode:centos6
 kreczko/workernode:centos7
+clelange/slc5-cms:latest
 
 # ATLAS worker node
 lincolnbryant/atlas-wn


### PR DESCRIPTION
I would like to make [this](https://hub.docker.com/r/clelange/slc5-cms/) container available via CVFMS so that we can run batch jobs with HTCondor on SLC5. This would be needed for the purposes of the CMS Data Preservation and Open Access group (@katilp) and beyond.

You can find details on this container at https://github.com/clelange/cmssw-docker, specifically in the corresponding [Dockerfile](https://github.com/clelange/cmssw-docker/blob/master/slc5-cms/Dockerfile).

Please let me know if you need any other information or have comments on the container contents and structure.