### PR TITLE
Added jeffersonlab/remoll and jeffersonlab/japan

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -185,3 +185,7 @@ evolinc/osg-evolinc-i:1.7.4
 
 # JLab CLAS12 Simulations
 jeffersonlab/clas12simulations:production
+
+# JLab Parity Simulations and Analysis
+jeffersonlab/remoll:latest
+jeffersonlab/japan:latest


### PR DESCRIPTION
Docker hub images for simulation and analysis of parity-violating electron scattering for precision electroweak measurements at Jefferson Lab.

These are both in service of the ~$25M MOLLER experiment at Jefferson Lab (but also ongoing experiments), which was included in the President's budget as a line item and is CD-0 approved in the Department of Energy.

Although we are using JLab internal resources, we are exploring OSG resources as well.