### PR TITLE
Add Fermigrid worker nodes images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -210,3 +210,7 @@ sugwg/prp:*
 # brainlife.io - An online platform for reproducible neuroscience.
 brainlife/mrtrix3:3.0_RC3
 brainlife/mcr:neurodebian1604-r2017a
+
+# Fermilab VO - Fermigrid worker nodes
+fermilab/fnal-wn-sl7
+fermilab/fnal-wn-sl6


### PR DESCRIPTION
Adding Fermilab VO worker nodes for use in OSG
Dockerfile very similar to Fermigrid worker nodes, provided by Fermilab's GCO

The images are in docker hub:
https://cloud.docker.com/u/fermilab/repository/docker/fermilab/fnal-wn-sl7
https://cloud.docker.com/u/fermilab/repository/docker/fermilab/fnal-wn-sl6

