### PR TITLE
Remove dcshrum/singularity:cowsay

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -39,7 +39,6 @@ opensciencegrid/osg-wn:3.3-testing-el7
 opensciencegrid/osg-wn:3.3-devel-el7
 
 # OSGVO
-dcshrum/singularity:cowsay
 opensciencegrid/npjoodi
 opensciencegrid/osgvo-ants
 opensciencegrid/osgvo-beagle


### PR DESCRIPTION
It appears the image is no longer present on docker hub, and the error is breaking the sync script.