### PR TITLE
Add nova experiment image to docker_images.txt

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -216,3 +216,6 @@ brainlife/mcr:neurodebian1604-r2017a
 # Fermilab VO - Fermigrid worker nodes
 fermilab/fnal-wn-sl7
 fermilab/fnal-wn-sl6
+
+# NOvA Experiment
+novaexperiment/el7-tensorflow-gpu:*


### PR DESCRIPTION
Requesting to add a new image to docker_images.txt to support GPU workflows for the NOvA experiment on the OSG.