### PR TITLE
Nova docker

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -218,4 +218,5 @@ fermilab/fnal-wn-sl7
 fermilab/fnal-wn-sl6
 
 # NOvA Experiment
+novaexperiment/el7-tensorflow-gpu:*
 novaexperiment/slf67:*

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -218,4 +218,4 @@ fermilab/fnal-wn-sl7
 fermilab/fnal-wn-sl6
 
 # NOvA Experiment
-novaexperiment/el7-tensorflow-gpu:*
+novaexperiment/slf67:*

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -216,3 +216,6 @@ brainlife/mcr:neurodebian1604-r2017a
 # Fermilab VO - Fermigrid worker nodes
 fermilab/fnal-wn-sl7
 fermilab/fnal-wn-sl6
+
+# NOvA Experiment
+novaexperiment/el7-tensorflow-gpu:*


### PR DESCRIPTION
Added the NOvA's Scientific Linux Fermi 6.7 image. 