### PR TITLE
add htmap-exec image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -231,3 +231,6 @@ novaexperiment/slf67:*
 
 #holosim (tree migration)
 astrand/holosim1
+
+# HTMap
+htcondor/htmap-exec:v0.4.1


### PR DESCRIPTION
https://hub.docker.com/r/htcondor/htmap-exec | https://github.com/htcondor/htmap

HTMap's default docker image