### PR TITLE
Add Ligo Virgo Kagra Container for LALSuite

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -229,3 +229,6 @@ astrand/holosim1
 
 # HTMap
 htcondor/htmap-exec:*
+
+# LIGO/VIRGO/KAGRA containers
+containers.ligo.org/lscsoft/lalsuite/*

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -1,8 +1,6 @@
 
 # This file is a list of Docker images to synchronize to singularity.opensciencegrid.org.
 
-containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.53:stretch
-
 # First, some generic CentOS images:
 centos:latest
 centos:centos6

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -231,4 +231,7 @@ astrand/holosim1
 htcondor/htmap-exec:*
 
 # LIGO/VIRGO/KAGRA containers
-containers.ligo.org/lscsoft/lalsuite/*
+containers.ligo.org/lscsoft/lalsuite/nightly:*
+containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.59:*
+containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.60:*
+containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.62:*


### PR DESCRIPTION
Add Ligo Virgo Kagra Containers to OSG for CVMFS publishing. This PR specifically adds containers for LALSuite.