### PR TITLE
Add section for LIGO user defined images; add J. Willis PyCBC image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -231,3 +231,6 @@ astrand/holosim1
 
 # HTMap
 htcondor/htmap-exec:*
+
+# LIGO - user defined images
+containers.ligo.org/joshua.willis/pycbc:latest


### PR DESCRIPTION
Per the LIGO/Condor/OSG face-to-face (that I'm attending remotely) I understand the current way to request that personal Docker containers be converted to Singularity images and published to CVMFS is a merge request to this file.

I didn't see any existing area for LIGO user defined images, so I've added one to the end.