### PR TITLE
Adding James Clark's rucio-for-LIGO utils

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -234,6 +234,7 @@ htcondor/htmap-exec:*
 
 # LIGO - user defined images
 containers.ligo.org/joshua.willis/pycbc:latest
+containers.ligo.org/james-clark/gwrucio:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
Adds an entry in `docker_images.txt` to publish a rucio-related container to CVMFS from the LIGO gitlab registry