### PR TITLE
LIGO BayesWave container images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -234,6 +234,7 @@ htcondor/htmap-exec:*
 
 # LIGO - user defined images
 containers.ligo.org/joshua.willis/pycbc:latest
+containers.ligo.org/james-clark/bayeswave:*
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7
@@ -244,6 +245,7 @@ containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.60:el7
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.60:stretch
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.62:el7
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.62:stretch
+containers.ligo.org/lscsoft/bayeswave:*
 
 # Lancaster U Muon g-2 Beamline Simulations
 valetov/g4bl:*


### PR DESCRIPTION
Adds images from containers.ligo.org for the LIGO burst analysis algorithm "BayesWave"