### PR TITLE
Ligo bayeswave images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -234,7 +234,7 @@ htcondor/htmap-exec:*
 
 # LIGO - user defined images
 containers.ligo.org/joshua.willis/pycbc:latest
-containers.ligo.org/james-clark/bayeswave:*
+containers.ligo.org/james-clark/bayeswave:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7
@@ -245,7 +245,9 @@ containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.60:el7
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.60:stretch
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.62:el7
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.62:stretch
-containers.ligo.org/lscsoft/bayeswave:*
+containers.ligo.org/lscsoft/bayeswave:nightly
+containers.ligo.org/lscsoft/bayeswave:latest
+containers.ligo.org/lscsoft/bayeswave:v1.0.4
 
 # Lancaster U Muon g-2 Beamline Simulations
 valetov/g4bl:*


### PR DESCRIPTION
Enumerates exactly which BayesWave images from the LIGO gitlab registry to publish. A previous attempt used a wildcard to publish all images but led to an apparent conflict in the gitlab and github tags APIs.