### PR TITLE
Python 2/3 images for Computational neuroscience

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -268,4 +268,8 @@ egstern/ubuntu1804-synergia2:*
 mu2e/synergia:v0
 egstern/wn-synergia2:latest
 
+#NEURON+Brian2+Python
+rtikid/python2-numpy-scipy-sympy-neuron-brian2-netpyne-inspyred-pyabf
+rtikid/python3-numpy-scipy-sympy-neuron-brian2-netpyne-inspyred-pyabf
+
 


### PR DESCRIPTION
Images for computational neuroscience  
  python 2.7.16 / 3.7.4
  numpy 1.16.5 
  scipy 1.2.2 
  sympy 1.4
  NEURON 7.6.7
  BRIAN 2.2.2.1
  netpyne 0.9.3.1
  inspyred 1.0
  pyabf 2.1.10