### PR TITLE
Requesting to add brainlife/mcr:r2019a container

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -231,6 +231,7 @@ sugwg/prp:*
 # brainlife.io - An online platform for reproducible neuroscience.
 brainlife/mrtrix3:3.0_RC3
 brainlife/mcr:neurodebian1604-r2017a
+brainlife/mcr:r2019a
 
 # Fermilab VO - Fermigrid worker nodes
 fermilab/fnal-wn-sl7


### PR DESCRIPTION
This is more or less a generic Matlab MCR for r2019, but since I didn't see it listed already, I'd like to request it now.