### PR TITLE
Add user-defined Bilby image for gravitational wave parameter estimation

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -258,6 +258,7 @@ htcondor/htmap-exec:*
 containers.ligo.org/joshua.willis/pycbc:latest
 containers.ligo.org/james-clark/bayeswave:latest
 containers.ligo.org/james-clark/gwrucio:latest
+containers.ligo.org/james-clark/bilby_pipe:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
Adds a [bilby](https://git.ligo.org/lscsoft/bilby_pipe) image for LIGO gravitational wave parameter estimation to CVMFS for OSG-deployment testing