### PR TITLE
Add ligo bilby image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -258,7 +258,7 @@ htcondor/htmap-exec:*
 containers.ligo.org/joshua.willis/pycbc:latest
 containers.ligo.org/james-clark/bayeswave:latest
 containers.ligo.org/james-clark/gwrucio:latest
-containers.ligo.org/james-clark/bilby_pipe:latest
+containers.ligo.org/james-clark/bilby_pipe_public:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -258,6 +258,7 @@ htcondor/htmap-exec:*
 containers.ligo.org/joshua.willis/pycbc:latest
 containers.ligo.org/james-clark/bayeswave:latest
 containers.ligo.org/james-clark/gwrucio:latest
+containers.ligo.org/james-clark/bilby_pipe:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
Adds an image to support gravitational wave parameter estimation using the Bilby pipeline.  Development version for initial OSG deployment tests.