### PR TITLE
Added FAST-HEP docker images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -293,3 +293,6 @@ rtikid/python3-numpy-scipy-sympy-neuron-brian2-netpyne-inspyred-pyabf
 
 # WRENNCH project (rynge)
 wrenchproject/task-clustering:*
+
+# FAST-HEP images
+fasthep/fast-hep-docker:version-0.2.0


### PR DESCRIPTION
Adds the FAST-HEP docker image. FAST is a toolkit to help high-level analyses, in particular, within particle physics. http://fast-hep.web.cern.ch/fast-hep/public/  Please can you add this to the cvmfs osg repo?