### PR TITLE
Added image in mintproject for the Drought Indices model

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -146,6 +146,8 @@ mintproject/weather-generator:*
 mintproject/mintviz:*
 mintproject/modflow-2005:*
 mintproject/topoflow:*
+mintproject/droughtindices:*
+
 
 # Lightweight images
 busybox


### PR DESCRIPTION
See https://hub.docker.com/r/mintproject/droughtindices/tags for more information about the image.