### PR TITLE
ENH add lsst desc stackvana image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -330,3 +330,6 @@ agitter/singe:latest
 
 # Notre Dame images
 notredamedulac/el7-tensorflow-pytorch:latest
+
+# LSST DESC stackvana
+beckermr/stackvana:latest


### PR DESCRIPTION
Note that this image uses both ENV and ENTRYPOINT commands in the dockerfile and those need to be preserved when it is converted to singularity.

cc @esheldon @tmcclintock