### PR TITLE
Remove ND amber image from docker_images.txt 

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -334,7 +334,6 @@ agitter/singe:latest
 notredamedulac/el7-tensorflow-pytorch:latest
 notredamedulac/el7-pytorch-gpu:latest
 notredamedulac/el7-tensorflow-keras-gpu:latest
-notredamedulac/amber:latest
 
 # LSST DESC stackvana
 beckermr/stackvana:latest


### PR DESCRIPTION
Sorry for the multiple PRs lately. It seems one of the container images can't be put into docker hub due to license issues, so I'm removing it from docker hub and from the list here.