### PR TITLE
Add cmssw/cms:rhel-itb containers

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -183,6 +183,8 @@ bbockelm/cms:rhel6
 bbockelm/cms:rhel7
 cmssw/cms:rhel6
 cmssw/cms:rhel7
+cmssw/cms:rhel6-itb
+cmssw/cms:rhel7-itb
 cmssw/cms:rhel6-m*
 cmssw/cms:rhel7-m*
 efajardo/docker-cms:tensorflow


### PR DESCRIPTION
Can you please include cmssw/cms:rhel[67]-itb containers. These are containers to be used by CMS testbed before we deploy them for production. 