### PR TITLE
Update docker_images.txt

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -296,6 +296,8 @@ containers.ligo.org/lscsoft/bayeswave:nightly
 containers.ligo.org/lscsoft/bayeswave:latest
 containers.ligo.org/lscsoft/bayeswave:v1.0.5
 containers.ligo.org/rucio/igwn-rucio-client/rucio-clients:latest
+containers.ligo.org/lscsoft/gstlal:O3b_online
+containers.ligo.org/lscsoft/gstlal:master
 
 # Lancaster U Muon g-2 Beamline Simulations
 valetov/g4bl:*


### PR DESCRIPTION
Add GstLAL LIGO/Virgo/KAGRA containers.  This change will allow us to access containers to run the GstLAL search software on OSG resources. These containers exist on the standard LVK container registry.