### PR TITLE
LIGO user image for Tests-of-GR lallinference parameter estimation study

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -282,6 +282,7 @@ containers.ligo.org/james-clark/research-projects-rit/rift:latest
 containers.ligo.org/james-clark/research-projects-rit/rift:production
 containers.ligo.org/tessa.carver/pygrb_o3a:latest
 atanasi/matlab:v97
+containers.ligo.org/james-clark/tgr_images/testing_gr_fta:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
Deploy an image for lalinference-based TGR studies for LIGO.  Uses source-installed fork of lalinference.