### PR TITLE
Add image to support CLAS simulations

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -369,3 +369,6 @@ gthain/rtest
 
 # Hieu Nguyen
 nguyenatrowan/pytorch
+
+# JLab CLAS Simulations
+tylern4/clas6:latest


### PR DESCRIPTION
Adding an image with the software necessary to run simulations for the CLAS collaboration experiments from the previous 6 GeV era at JLab.