### PR TITLE
Add latest LIGO BayesWave release image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -310,9 +310,9 @@ containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.60:el7
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.60:stretch
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.62:el7
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.62:stretch
-containers.ligo.org/lscsoft/bayeswave:nightly
 containers.ligo.org/lscsoft/bayeswave:latest
 containers.ligo.org/lscsoft/bayeswave:v1.0.5
+containers.ligo.org/lscsoft/bayeswave:v1.0.6
 containers.ligo.org/rucio/igwn-rucio-client/rucio-clients:latest
 containers.ligo.org/lscsoft/gstlal:O3b_online
 containers.ligo.org/lscsoft/gstlal:master


### PR DESCRIPTION
Adds the latest release of the LIGO unmodelled burst analysis BayesWave (v1.0.6).  Retains the v1.0.5 release for reproducibility.  Also removes the nightly build of this container.