### PR TITLE
CMS L1T analysis development and tagged release containers

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -211,6 +211,9 @@ efajardo/docker-cms:tensorflow
 kreczko/workernode:centos6
 kreczko/workernode:centos7
 clelange/slc5-cms:latest
+# CMS L1 trigger analysis
+cmsl1tanalysis/cmsl1t-dev:*
+cmsl1tanalysis/cmsl1t:*
 
 # ATLAS worker node
 lincolnbryant/atlas-wn


### PR DESCRIPTION
Added containers for CMS L1 trigger analysis package.
 - `cmsl1tanalysis/cmsl1t-dev:*` hold the base requirements (cutting edge) and is used for development
 - `cmsl1tanalysis/cmsl1t:*` contain tagged releases of the software