### PR TITLE
Adding an image of Scientific Linux 7 for the NOvA experiment

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -284,6 +284,7 @@ fermilab/fnal-wn-sl6
 novaexperiment/el7-tensorflow-gpu:*
 novaexperiment/nova-sl7-novat2k:*
 novaexperiment/slf67:*
+novaexperiment/sl7:*
 
 #holosim (tree migration)
 astrand/holosim


### PR DESCRIPTION
Adding [this SL7 docker image from dockerhub](https://hub.docker.com/r/novaexperiment/sl7) for the NOvA experiment. 