### PR TITLE
I added the first ZTF docker image under Zwicky Transient Facility

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -407,3 +407,6 @@ opengatecollaboration/gate:9.0
 
 # Snowmass21
 snowmass21software/delphes-osg:*
+
+# Zwicky Transient Facility
+michaelwcoughlin/ztfperiodic:latest


### PR DESCRIPTION
This image is for light curve period finding and periodicity metrics.