### PR TITLE
Increment LIGO bayeswave image version

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -337,8 +337,8 @@ containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.60:stretch
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.62:el7
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.62:stretch
 containers.ligo.org/lscsoft/bayeswave:latest
-containers.ligo.org/lscsoft/bayeswave:v1.0.5
 containers.ligo.org/lscsoft/bayeswave:v1.0.6
+containers.ligo.org/lscsoft/bayeswave:v1.0.7
 containers.ligo.org/rucio/igwn-rucio-client/rucio-clients:latest
 containers.ligo.org/lscsoft/gstlal:osg_dag_workflow
 containers.ligo.org/lscsoft/gstlal:O3b_online


### PR DESCRIPTION
Deploys new version of LIGO's BayesWave algorithm and removes the older version.