### PR TITLE
Includes uboonecode+galler-fwmk docker definition

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -440,3 +440,6 @@ intel/oneapi-hpckit
 
 # E1039/SpinQuest
 e1039/e1039-sl7
+
+# University of Manchester/MicroBooNE uboonecode + gallery-fmwk
+lmlepin9/slf7-ubcode-gallery-fmwk


### PR DESCRIPTION
Hi, we would like to include my docker definition into /cvmfs so It will be available to use over the fermigrid. 