### PR TITLE
k3jph/torch-diffeq to Singularity images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -128,6 +128,7 @@ jonlam/osg_ubuntu:latest
 jml230/osg-amber:*
 justbennet/seas:lidar
 kai2019/osg-fsl:latest
+k3jph/torch-diffeq:latest
 leofang/cthyb-ohmic
 m8zeng/julia-packages
 mfrayer/perl-stats


### PR DESCRIPTION
Adds Python 3.9 with PyTorch, torchcde, torchsde for solving differential equations