### PR TITLE
Update LIGO lalsuite nightly image from stretch to buster

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -336,7 +336,7 @@ containers.ligo.org/alec.gunny/deepclean-prod:server-20.07
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7
-containers.ligo.org/lscsoft/lalsuite/nightly:stretch
+containers.ligo.org/lscsoft/lalsuite/nightly:buster
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.59:el7
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.59:stretch
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.60:el7


### PR DESCRIPTION
The nightly Debian stretch based build of the LIGO Algorithm Library has been replaced with a Debian Buster build.  The stretch image was recently removed.