### PR TITLE
Adds image for GAPS experiment

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -449,3 +449,6 @@ lmlepin9/slf7-ubcode-gallery-fmwk:2.0
 
 # University of Guam - Bioinformatics
 jagault/evolution-photosymbiosis:rscriptv3.5.3
+
+# GAPS - General Anti Particle Spectrometer
+gapscr/crane:1.6.4


### PR DESCRIPTION
The General Anti Particle Spectrometer (GAPS) is a  balloon-borne cosmic-ray experiment scheduled for long-duration balloon flights from McMurdo Station in the Antarctic. Its primary science goal is the search for light antinuclei in cosmic rays at energies in the region below 0.3 GeV/n. This energy region is of great interest and still mostly uncharted. Searches for light antimatter nucleons with energies below ~0.3 GeV/n promise a potential break-through approach for the search of dark matter. GAPS will search with unprecedented sensitivity for antiprotons and especially antideuterons.