### PR TITLE
New images: eicweb/jug_xl, for Electron-Ion Collider ATHENA collaboration

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -194,6 +194,9 @@ whit2333/eic-slic:latest
 argonneeic/evochain:v*
 argonneeic/fpadsim:v*
 electronioncollider/escalate:latest
+eicweb/jug_xl:*-stable
+eicweb/jug_xl:testing
+eicweb/jug_xl:nightly
 
 # Common biology tools
 # Biocontainers :latest doesn't exist any longer.


### PR DESCRIPTION
These images for the Electron-Ion Collider (EIC) will be used for the simulation campaign of the ATHENA collaboration between now and the end of 2021 (and hopefully later too), on a variety of resources worldwide.