### PR TITLE
adding read-only image for becheler

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -100,6 +100,7 @@ agladstein/simprily_autobuild
 anniesoft/toolanalysis
 arburks/aris-convert:latest
 arnaudbecheler/quetzal-eggs:*
+arnaudbecheler/quetzal-open-science-grid:*
 blaylockbk/miniconda3_osg:latest
 blibgober/pdf_converter:latest
 bpschenke/ipglasma:latest


### PR DESCRIPTION
I'm a participant of the OSG virtual school, working on spatial genetics simulation. I had to create a second Docker image because for the first one (quetzal-eggs) would be read-only. Sorry for that! 
Thank you !