### PR TITLE
adding opencarp image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -150,6 +150,7 @@ npcooley/heron:latest
 npcooley/deepec:latest
 npcooley/phylosim:latest
 npcooley/synextend:*
+docker.opencarp.org/opencarp/opencarp:latest
 parabola505/geospatxgboost:*
 rafaelnalin/r-ver-openblas:latest
 relugzosiraba/kwant_adaptive:v1


### PR DESCRIPTION
This image isn't on docker hub -- it's hosted on a separate (public?) registry. is that okay?