### PR TITLE
adding gw inference-as-a-service export container

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -358,6 +358,7 @@ containers.ligo.org/james-clark/tgr_images/lalsuite-master:latest
 containers.ligo.org/alec.gunny/deepclean-prod:export-20.07
 containers.ligo.org/alec.gunny/deepclean-prod:client-20.07
 containers.ligo.org/alec.gunny/deepclean-prod:server-20.07
+fastml/gw-iaas-export
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
Adding a dockerhub container built by [this repo](https://github.com/fastmachinelearning/gw-iaas) for deploying DL applications in LIGO