### PR TITLE
Update PyCBC singularity images to move to 2.X

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -230,9 +230,10 @@ igwn/software:stretch
 igwn/software:stretch-proposed
 
 # LIGO PyCBC compute nodes
-pycbc/pycbc-el7:v1.16.*
-pycbc/pycbc-el7:v1.18.*
-pycbc/pycbc-el7:latest
+pycbc/pycbc-el7:v1.16.12
+pycbc/pycbc-el7:v1.18.3
+pycbc/pycbc-el8:v2.0.*
+pycbc/pycbc-el8:latest
 
 # CMS worker node
 bbockelm/cms:rhel6


### PR DESCRIPTION
We've transitioned to the 2.X series of PyCBC so this PR requests that we update the docker images that we publish into CVMFS singularity images. As part of that, we've also moved to an EL8 based image, so there's a name change to reflect that.  Finally, at least for now, we'd like to keep the last singularity images of both the 1.16 and 1.18 series, so those two releases are explicitly named; any others from those series don't need to stay around (from our point of view).