### PR TITLE
Add jeffersonlab/gluex_devel:latest.

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -274,6 +274,7 @@ rjones30/gluextest
 markito3/gluex_docker_devel
 markito3/gluex_docker_prod
 jeffersonlab/gluex_prod:v1
+jeffersonlab/gluex_devel:latest
 
 # WIPAC (IceCube)
 wipac/fasig_scalable_radio_array


### PR DESCRIPTION
Moving official containers out of the markito3 account to the JeffersonLab organization on DockerHub.