### PR TITLE
Update set of LIGO GstLAL images in use

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -380,9 +380,8 @@ containers.ligo.org/lscsoft/bayeswave:latest
 containers.ligo.org/lscsoft/bayeswave:v1.0.6
 containers.ligo.org/lscsoft/bayeswave:v1.0.7
 containers.ligo.org/computing/rucio/containers/rucio-clients:latest
-containers.ligo.org/lscsoft/gstlal:osg_dag_workflow
-containers.ligo.org/lscsoft/gstlal:O3b_online
 containers.ligo.org/lscsoft/gstlal:master
+containers.ligo.org/lscsoft/gstlal:o4-online-dev
 containers.ligo.org/lmxbcrosscorr/containers:crosscorr-lattice-dev-clean
 containers.ligo.org/echoes-model-independent/bayeswave-echoes-image:v1.0.7_echoes_reviewed
 


### PR DESCRIPTION
The two GstLAL images that have been removed are not in use anymore, and one has been added as well.