### PR TITLE
Allow any tag for Fermilab images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -325,9 +325,9 @@ brainlife/mcr:neurodebian1604-r2017a
 brainlife/mcr:r2019a
 
 # Fermilab VO - Fermigrid worker nodes
-fermilab/fnal-wn-el8
-fermilab/fnal-wn-sl7
-fermilab/fnal-wn-sl6
+fermilab/fnal-wn-el8:*
+fermilab/fnal-wn-sl7:*
+fermilab/fnal-wn-sl6:*
 
 # NOvA Experiment
 novaexperiment/el7-tensorflow-gpu:*


### PR DESCRIPTION
With this PR we are enabling all tags for Fermilab images.
This allows to create and test different image configurations for the same OS