### PR TITLE
remove gstlal image o4-online, add o4-offline-dev

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -389,7 +389,7 @@ containers.ligo.org/lscsoft/bayeswave:v1.0.6
 containers.ligo.org/lscsoft/bayeswave:v1.0.7
 containers.ligo.org/computing/rucio/containers/rucio-clients:latest
 containers.ligo.org/lscsoft/gstlal:master
-containers.ligo.org/lscsoft/gstlal:o4-online
+containers.ligo.org/lscsoft/gstlal:o4-offline-dev
 containers.ligo.org/lscsoft/gstlal:o4-online-dev
 containers.ligo.org/lmxbcrosscorr/containers:crosscorr-lattice-dev-clean
 containers.ligo.org/echoes-model-independent/bayeswave-echoes-image:v1.0.7_echoes_reviewed


### PR DESCRIPTION
The o4-online branch of GstLAL is no longer used. This change replaces the o4-online image with one from o4-offline-dev to allow testing of offline development on the OSG.