### PR TITLE
Add cw-frequencyhough docker image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -374,6 +374,7 @@ containers.ligo.org/alec.gunny/deepclean-prod:server-20.07
 fastml/gwiaas.export:latest
 fastml/gwiaas.tritonserver:latest
 containers.ligo.org/cwinpy/cwinpy-containers/cwinpy-dev-python38:latest
+containers.ligo.org/rhys.poulton/cw-frequencyhough:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -374,7 +374,7 @@ containers.ligo.org/alec.gunny/deepclean-prod:server-20.07
 fastml/gwiaas.export:latest
 fastml/gwiaas.tritonserver:latest
 containers.ligo.org/cwinpy/cwinpy-containers/cwinpy-dev-python38:latest
-containers.ligo.org/rhys.poulton/cw-frequencyhough:latest
+containers.ligo.org/rhys.poulton/cw-frequencyhough-image:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
This image contains the cw-frequencyhough gravitational wave pipeline which is the Rome project for All-Sky searches. This is currently in my namespace for testing.