### PR TITLE
Add cw-frequencyhough:escape-datalake docker image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -377,6 +377,7 @@ fastml/gwiaas.export:latest
 fastml/gwiaas.tritonserver:latest
 containers.ligo.org/cwinpy/cwinpy-containers/cwinpy-dev-python38:latest
 containers.ligo.org/rhys.poulton/cw-frequencyhough-image:latest
+containers.ligo.org/rhys.poulton/cw-frequencyhough-image:escape-datalake
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
This image contains the cw-frequencyhough gravitational wave pipeline which is the Rome project for All-Sky searches. The image is also designed to pull data from ESCAPE datalake which the pipeline is then run on. This is currently in my namespace for testing.