### PR TITLE
Add larcv2 image ref

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -99,6 +99,7 @@ agladstein/msprime:latest
 agladstein/simprily:latest
 agladstein/simprily:version1
 agladstein/simprily_autobuild
+amogan/larcv2:ub20.04-cuda11.0-pytorch1.7.1-larndsim-cvmfs
 anniesoft/toolanalysis
 anniesoft/wcsim
 arburks/aris-convert:latest


### PR DESCRIPTION
This image is essentially a copy of the one maintained by the [DeepLearnPhysics](https://hub.docker.com/r/deeplearnphysics/larcv2) group, but with a /cvmfs directory added. Having this image available on OSG will allow our group to streamline our simulation production chain.