### PR TITLE
LIGO user images for tests of general relativity with the SEOB waveform model

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -384,6 +384,8 @@ fastml/gwiaas.tritonserver:latest
 containers.ligo.org/cwinpy/cwinpy-containers/cwinpy-dev-python38:latest
 containers.ligo.org/rhys.poulton/cw-frequencyhough-image:latest
 containers.ligo.org/rhys.poulton/cw-frequencyhough-image:escape-datalake
+containers.ligo.org/aei-tgr/cvmfs-images/pseob-rd:20220828
+containers.ligo.org/aei-tgr/cvmfs-images/seob-rom:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
Deploy an image for tests of general relativity with the SEOB waveform model with several changes that are not yet in the IGWN conda environments.