### PR TITLE
Add htcondor/hpc-annex-pilot from hub.opensciencegrid.org

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -356,9 +356,9 @@ egoodman/t2knova_mach3_configdata:PostBANFF
 astrand/holosim
 astrand/popassemble
 
-# HTMap
+# HTMap/HTCondor Software
 htcondor/htmap-exec:*
-
+hub.opensciencegrid.org/htcondor/hpc-annex-pilot:*
 
 # LIGO - user defined images
 containers.ligo.org/cody.messick/container:latest

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -358,7 +358,10 @@ astrand/popassemble
 
 # HTMap/HTCondor Software
 htcondor/htmap-exec:*
-hub.opensciencegrid.org/htcondor/hpc-annex-pilot:*
+# cvmfs-singularity-sync does not yet support wildcard tags from hub.opensciencegrid.org
+#hub.opensciencegrid.org/htcondor/hpc-annex-pilot:*
+hub.opensciencegrid.org/htcondor/hpc-annex-pilot:el8
+hub.opensciencegrid.org/htcondor/hpc-annex-pilot:latest
 
 # LIGO - user defined images
 containers.ligo.org/cody.messick/container:latest


### PR DESCRIPTION
This is an environment used to run the HPC Annex on the PATh Facility.
Fairly internal, which is why it's only on Harbor.