### PR TITLE
Add rockylinux:8

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -13,6 +13,7 @@ debian:testing
 debian:unstable
 ubuntu:latest
 fedora:latest
+rockylinux:8
 
 # Common programming environments
 python:latest


### PR DESCRIPTION
Useful to have a base EL8 image; `rockylinux:8` is what we use in osgvo-el8.