### PR TITLE
removing old deepclean and triton images and updating for ml4gw

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -403,17 +403,15 @@ atanasi/darkmatter:latest
 lucarvirgo/tensorflowmatlab:latest
 containers.ligo.org/james-clark/tgr_images/testing_gr_fta:latest
 containers.ligo.org/james-clark/tgr_images/lalsuite-master:latest
-containers.ligo.org/alec.gunny/deepclean-prod:export-20.07
-containers.ligo.org/alec.gunny/deepclean-prod:client-20.07
-containers.ligo.org/alec.gunny/deepclean-prod:server-20.07
-fastml/gwiaas.export:latest
-fastml/gwiaas.tritonserver:latest
 containers.ligo.org/cwinpy/cwinpy-containers/cwinpy-dev-python38:latest
 containers.ligo.org/rhys.poulton/cw-frequencyhough-image:latest
 containers.ligo.org/rhys.poulton/cw-frequencyhough-image:escape-datalake
 containers.ligo.org/aei-tgr/cvmfs-images/pseob-rd:20220828
 containers.ligo.org/aei-tgr/cvmfs-images/seob-rom:latest
 containers.ligo.org/alan.knee/lal-images/lalsuite-fstatbinary:latest
+ghcr.io/ml4gw/hermes/tritonserver:22.07
+ghcr.io/ml4gw/hermes/tritonserver:22.02
+ghcr.io/ml4gw/pinto:main
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/nightly:el7


### PR DESCRIPTION
Removes `deepclean` images which are no longer in use, and images associated with libraries that used to be hosted under the `fastml` org and have been moved to a new `ml4gw` org to focus specifically on ML applications to GW physics.  The containers being added represent:
- Two different versions of the `tritonserver` ML-inference-as-a-service application which have been compiled against different versions of the accelerated TensorRT inference library
- A custom-built environment management utility called `pinto` which we leverage extensively in maintaining and versioning ML environments and pipelines

These containers are built and tested automatically as part of our CI pipelines and will grow as we build more ML tools and fully containerize experiments built on them.