### PR TITLE
Updated LIGO images for tests of general relativity with the SEOB waveform model

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -407,7 +407,10 @@ containers.ligo.org/james-clark/tgr_images/lalsuite-master:latest
 containers.ligo.org/cwinpy/cwinpy-containers/cwinpy-dev-python38:latest
 containers.ligo.org/rhys.poulton/cw-frequencyhough-image:latest
 containers.ligo.org/rhys.poulton/cw-frequencyhough-image:escape-datalake
-containers.ligo.org/aei-tgr/cvmfs-images/pseob-rd:20220828
+containers.ligo.org/aei-tgr/cvmfs-images/pseob:rd-latest
+containers.ligo.org/aei-tgr/cvmfs-images/pseob:fti-latest
+containers.ligo.org/aei-tgr/cvmfs-images/pseob:testing
+containers.ligo.org/aei-tgr/cvmfs-images/pseob:envs
 containers.ligo.org/aei-tgr/cvmfs-images/seob-rom:latest
 containers.ligo.org/alan.knee/lal-images/lalsuite-fstatbinary:latest
 ghcr.io/ml4gw/hermes/tritonserver:22.07


### PR DESCRIPTION
Updated LIGO images for tests of general relativity with the SEOB waveform model (ringdown test, FTI test, code testing, conda environments).