### PR TITLE
Update PyCBC CVMFS envs to 2.2.*

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -274,7 +274,7 @@ igwn/software:stretch-proposed
 # LIGO PyCBC compute nodes
 pycbc/pycbc-el7:v1.16.12
 pycbc/pycbc-el7:v1.18.3
-pycbc/pycbc-el8:v2.0.*
+pycbc/pycbc-el8:v2.2.*
 pycbc/pycbc-el8:latest
 
 # CMS worker node


### PR DESCRIPTION
PyCBC has now released version 2.2.0. As LIGO/Virgo/KAGRA prepares for O4 we would like to keep the latest release branch on CVMFS for production runs. We may yet bump this to 2.3.* before O4 runs begin.