### PR TITLE
Add SNAX toolkit images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -459,6 +459,8 @@ containers.ligo.org/computing/rucio/containers/rucio-clients:latest
 containers.ligo.org/lscsoft/gstlal:master
 containers.ligo.org/lscsoft/gstlal:o4-offline-dev
 containers.ligo.org/lscsoft/gstlal:o4-online-dev
+containers.ligo.org/snax/snax:v0.5.1
+containers.ligo.org/snax/snax:v0.5.2
 containers.ligo.org/lmxbcrosscorr/containers:crosscorr-lattice-dev-clean
 containers.ligo.org/echoes-model-independent/bayeswave-echoes-image:v1.0.7_echoes_reviewed
 


### PR DESCRIPTION
Add SNAX images from containers.ligo.org for inclusion into /cvmfs.