### PR TITLE
LIGO images for tests of general relativity: testing v5 version of the SEOB waveform model

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -455,6 +455,7 @@ containers.ligo.org/aei-tgr/cvmfs-images/pseob:fti-latest
 containers.ligo.org/aei-tgr/cvmfs-images/pseob:testing
 containers.ligo.org/aei-tgr/cvmfs-images/pseob:envs
 containers.ligo.org/aei-tgr/cvmfs-images/seob-rom:latest
+containers.ligo.org/aei-tgr/cvmfs-images/seob-rom:v5
 containers.ligo.org/alan.knee/lal-images/lalsuite-fstatbinary:latest
 ghcr.io/ml4gw/hermes/tritonserver:22.12
 ghcr.io/ml4gw/hermes/tritonserver:22.07


### PR DESCRIPTION
Updated LIGO images for tests of general relativity with the SEOB waveform model to include the v5 version of the SEOB waveform model.