### PR TITLE
Update PyCBC LIGO images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -295,7 +295,7 @@ igwn/software:stretch-proposed
 # LIGO PyCBC compute nodes
 pycbc/pycbc-el7:v1.16.12
 pycbc/pycbc-el7:v1.18.3
-pycbc/pycbc-el8:v2.2.*
+pycbc/pycbc-el8:v2.3.*
 pycbc/pycbc-el8:latest
 
 # CMS worker node


### PR DESCRIPTION
PyCBC LIGO analyses for the ongoing LIGO/Virgo/KAGRA observing run will soon get going on OSG. We will use the v2.3.X release branch for this, and so I update the images here. I remove the v2.2.X branch, as we no longer will need that.