### PR TITLE
Add a GPU burn image for IGWN pool testing

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -487,6 +487,7 @@ ghcr.io/ml4gw/hermes/tritonserver:22.07
 ghcr.io/ml4gw/hermes/tritonserver:22.02
 ghcr.io/ml4gw/pinto:main
 containers.ligo.org/yannick.lecoeuche/glitch-pe-container/glitch-pe:latest
+containers.ligo.org/computing/distributed/igwn-pool-exorciser/gpu_burn:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.59:el7


### PR DESCRIPTION
Adds an apptainer image for [GPU burn](https://github.com/wilicc/gpu-burn) for IGWN pool functionality tests