### PR TITLE
Remove lalsuite-dev:stretch

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -288,7 +288,6 @@ cyverse/rsem-prepare
 
 # IGWN (Internation Gravitational Wave Network) worker nodes
 igwn/lalsuite-dev:el7
-igwn/lalsuite-dev:stretch
 igwn/software:el7
 igwn/software:el7-testing
 igwn/software:stretch


### PR DESCRIPTION
The image has been removed from Docker Hub. Confirmed with @josh-willis over Slack.