### PR TITLE
Updates to EIC container images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -273,12 +273,10 @@ alpine
 whit2333/eic-slic:latest
 argonneeic/evochain:v*
 argonneeic/fpadsim:v*
-electronioncollider/escalate:latest
 eicweb/jug_xl:*-stable
-eicweb/jug_xl:*-beta
-eicweb/jug_xl:*-alpha
-eicweb/jug_xl:testing
 eicweb/jug_xl:nightly
+eicweb/eic_xl:*-stable
+eicweb/eic_xl:nightly
 raygunkennesaw/tensorflow:1.2.0-py3
 
 # Common biology tools


### PR DESCRIPTION
The EIC images are going through a renaming, from jug_* to eic_*. This reflects a more general user base and application domain than the 'juggler' event reconstruction framework from which the prior name originated. We are maintaining the older name for the nightly images for the duration of this transition.

We are also removing the alpha, beta and testing releases from cvmfs sync, as well as the obsolete escalate image.

Cc: @mdiefent @sly2j @wenaus @rahmans1 @t-britton