### PR TITLE
Added Fermilab SL7 development image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -413,6 +413,7 @@ fermilab/fnal-wn-el9:*
 fermilab/fnal-wn-el8:*
 fermilab/fnal-wn-sl7:*
 fermilab/fnal-wn-sl6:*
+fermilab/fnal-dev-sl7:*
 fermilab/benchmark:*
 
 # NOvA Experiment


### PR DESCRIPTION
The SL7 development image will be used by experiments to build and maintain SL7 software