### PR TITLE
Update docker_images.txt

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -233,6 +233,7 @@ rhughwhite/minimac3:2.0.1
 biocontainers/minimac4:v1.0.0-2-deb_cv1
 nnesquivelr/decam_proc_base:*
 dxando/rift-container:latest
+mascencio/al9g4bnb:latest
 
 # Geant4 simulation and analysis tools
 physino/gears


### PR DESCRIPTION
Adding a G4BNB container. The new G4BNB simulation is built on AlmaLinux9 and includes ROOT, Geant4 10.6.1, and Boost 1.85.0.