### PR TITLE
Adding a DINGO docker image 

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -501,6 +501,7 @@ containers.ligo.org/computing/distributed/igwn-pool-exorciser/gpu_burn:latest
 containers.ligo.org/colm.talbot/bilby-pipe-image-sandbox/bilby-pipe-production-python311:latest
 containers.ligo.org/colm.talbot/bilby-pipe-image-sandbox/gwpopulation-python311:latest
 containers.ligo.org/tomasz.baka/tgr-docker-image/bilby_tgr:latest
+containers.ligo.org/nihar.gupte/dingo-ci/dingo:latest
 
 # LIGO/VIRGO/KAGRA containers
 containers.ligo.org/lscsoft/lalsuite/lalsuite-v6.59:el7


### PR DESCRIPTION
Creating docker image for DINGO: https://github.com/dingo-gw/dingo to put onto CVMFS