### PR TITLE
EIC: add nightly CUDA production and development images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -284,6 +284,8 @@ eicweb/jug_xl:*-stable
 eicweb/jug_xl:nightly
 eicweb/eic_xl:*-stable
 eicweb/eic_xl:nightly
+eicweb/eic_cuda:nightly
+eicweb/eic_dev_cuda:nightly
 raygunkennesaw/tensorflow:1.2.0-py3
 
 # Common biology tools


### PR DESCRIPTION
We have been developing additional CUDA functionality that we are ready to start using in production on OSG systems.

These two images are for production (i.e. CUDA runtime only) and development (i.e. CUDA devel) containers. The development containers will likely be needed in the short term to facilitate debugging of issues we may encounter.

Both images are layered in such a way that the large CUDA layers are unchanging and at the base of the layer stack. This should made updates of these images no more storage intensive than the other EIC nightly images.