### PR TITLE
fix: switch to ghcr.io for eic images; rm older jug_* images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -275,12 +275,10 @@ alpine
 whit2333/eic-slic:latest
 argonneeic/evochain:v*
 argonneeic/fpadsim:v*
-eicweb/jug_xl:*-stable
-eicweb/jug_xl:nightly
-eicweb/eic_xl:*-stable
-eicweb/eic_xl:nightly
-eicweb/eic_cuda:nightly
-eicweb/eic_dev_cuda:nightly
+ghcr.io/eic/eic_xl:*-stable
+ghcr.io/eic/eic_xl:nightly
+ghcr.io/eic/eic_cuda:nightly
+ghcr.io/eic/eic_dev_cuda:nightly
 raygunkennesaw/tensorflow:1.2.0-py3
 
 # Common biology tools


### PR DESCRIPTION
To avoid rate limiting on docker hub, switch to ghcr.io. Ref: https://support.opensciencegrid.org/support/tickets/public/971a44287b1ba434c46e7207e853cc18dc1be94e7f0a7ebc05a07216f23f11e9