### PR TITLE
fix: replace eic glob with explicit list

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -275,7 +275,43 @@ alpine
 whit2333/eic-slic:latest
 argonneeic/evochain:v*
 argonneeic/fpadsim:v*
-ghcr.io/eic/eic_xl:*-stable
+# old dockerhub globbing for backwards compatibility during transition to ghcr.io
+eicweb/eic_xl:*-stable
+# globs fail on ghcr.io for now, so explicit listing
+# ghcr.io/eic/eic_xl:*-stable
+ghcr.io/eic/eic_xl:24.03.1-stable
+ghcr.io/eic/eic_xl:24.03-stable
+ghcr.io/eic/eic_xl:24.04.0-stable
+ghcr.io/eic/eic_xl:24.04-stable
+ghcr.io/eic/eic_xl:24.05.0-stable
+ghcr.io/eic/eic_xl:24.05.2-stable
+ghcr.io/eic/eic_xl:24.05-stable
+ghcr.io/eic/eic_xl:24.06.0-stable
+ghcr.io/eic/eic_xl:24.06-stable
+ghcr.io/eic/eic_xl:24.07.0-stable
+ghcr.io/eic/eic_xl:24.07-stable
+ghcr.io/eic/eic_xl:24.08.0-stable
+ghcr.io/eic/eic_xl:24.08.1-stable
+ghcr.io/eic/eic_xl:24.08-stable
+ghcr.io/eic/eic_xl:24.09.0-stable
+ghcr.io/eic/eic_xl:24.09-stable
+ghcr.io/eic/eic_xl:24.10.0-stable
+ghcr.io/eic/eic_xl:24.10.1-stable
+ghcr.io/eic/eic_xl:24.10-stable
+ghcr.io/eic/eic_xl:24.11.0-stable
+ghcr.io/eic/eic_xl:24.11.1-stable
+ghcr.io/eic/eic_xl:24.11.2-stable
+ghcr.io/eic/eic_xl:24.11-stable
+ghcr.io/eic/eic_xl:24.12.0-stable
+ghcr.io/eic/eic_xl:24.12-stable
+ghcr.io/eic/eic_xl:25.01.0-stable
+ghcr.io/eic/eic_xl:25.01.1-stable
+ghcr.io/eic/eic_xl:25.01-stable
+ghcr.io/eic/eic_xl:25.02.0-stable
+ghcr.io/eic/eic_xl:25.02-stable
+ghcr.io/eic/eic_xl:25.03.0-stable
+ghcr.io/eic/eic_xl:25.03.1-stable
+ghcr.io/eic/eic_xl:25.03-stable
 ghcr.io/eic/eic_xl:nightly
 ghcr.io/eic/eic_cuda:nightly
 ghcr.io/eic/eic_dev_cuda:nightly

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -276,6 +276,8 @@ whit2333/eic-slic:latest
 argonneeic/evochain:v*
 argonneeic/fpadsim:v*
 # old dockerhub globbing for backwards compatibility during transition to ghcr.io
+eicweb/eic_xl:25.04.0-stable
+eicweb/eic_xl:25.04-stable
 eicweb/eic_xl:*-stable
 # globs fail on ghcr.io for now, so explicit listing
 # ghcr.io/eic/eic_xl:*-stable

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -312,6 +312,8 @@ ghcr.io/eic/eic_xl:25.02-stable
 ghcr.io/eic/eic_xl:25.03.0-stable
 ghcr.io/eic/eic_xl:25.03.1-stable
 ghcr.io/eic/eic_xl:25.03-stable
+ghcr.io/eic/eic_xl:25.04.0-stable
+ghcr.io/eic/eic_xl:25.04-stable
 ghcr.io/eic/eic_xl:nightly
 ghcr.io/eic/eic_cuda:nightly
 ghcr.io/eic/eic_dev_cuda:nightly


### PR DESCRIPTION
Following up on #496, this PR replaces the ghcr.io glob with an explicit list. Also readded the dockerhub glob while we transition because we actually have a different username on dockerhub than on ghcr, so the paths change.

Tag @jasoncpatton