### PR TITLE
fix: for now keep nightly eic images on docker under eicweb as well

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -276,6 +276,9 @@ whit2333/eic-slic:latest
 argonneeic/evochain:v*
 argonneeic/fpadsim:v*
 # old dockerhub globbing for backwards compatibility during transition to ghcr.io
+eicweb/eic_xl:nightly
+eicweb/eic_cuda:nightly
+eicweb/eic_dev_cuda:nightly
 eicweb/eic_xl:25.04.0-stable
 eicweb/eic_xl:25.04-stable
 eicweb/eic_xl:*-stable


### PR DESCRIPTION
It turns out that removing the eicweb nightly images has broken still too much right now. We'd like to add them back and more gradually roll out the transition to ghcr.io over the next working week or so.

FYI @rynge