### PR TITLE
docker_images.txt: add eic_xl:25.04.1-stable

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -318,6 +318,7 @@ ghcr.io/eic/eic_xl:25.03.0-stable
 ghcr.io/eic/eic_xl:25.03.1-stable
 ghcr.io/eic/eic_xl:25.03-stable
 ghcr.io/eic/eic_xl:25.04.0-stable
+ghcr.io/eic/eic_xl:25.04.1-stable
 ghcr.io/eic/eic_xl:25.04-stable
 ghcr.io/eic/eic_xl:nightly
 ghcr.io/eic/eic_cuda:nightly

--- a/docker_images.txt
+++ b/docker_images.txt
@@ -280,6 +280,7 @@ eicweb/eic_xl:nightly
 eicweb/eic_cuda:nightly
 eicweb/eic_dev_cuda:nightly
 eicweb/eic_xl:25.04.0-stable
+eicweb/eic_xl:25.04.1-stable
 eicweb/eic_xl:25.04-stable
 eicweb/eic_xl:*-stable
 # globs fail on ghcr.io for now, so explicit listing


### PR DESCRIPTION
We need to use this new release.
It doesn't look like dockerhub globbing has been fixed. Let's add explicit ghcr container for now.