### PR TITLE
Remove LIGO igwn-wave-compare image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -491,7 +491,6 @@ hub.opensciencegrid.org/htcondor/hpc-annex-pilot:el8
 hub.opensciencegrid.org/htcondor/hpc-annex-pilot:latest
 
 # LIGO - user defined images
-containers.ligo.org/bayeswave/igwn-wave-compare:latest
 containers.ligo.org/cody.messick/container:latest
 containers.ligo.org/joshua.willis/pycbc:latest
 containers.ligo.org/james-clark/bayeswave:latest


### PR DESCRIPTION
This container registry is (now?) private.  This image has not been updated in 2 years so I'm removing this, at least until we have some evidence it is required and the registry is made public.