### PR TITLE
eic: add backwards compatibility test images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -268,12 +268,11 @@ argonneeic/fpadsim:v*
 eicweb/eic_xl:nightly
 eicweb/eic_cuda:nightly
 eicweb/eic_dev_cuda:nightly
-eicweb/eic_xl:25.04.0-stable
-eicweb/eic_xl:25.04.1-stable
-eicweb/eic_xl:25.04-stable
 eicweb/eic_xl:*-stable
 ghcr.io/eic/eic_ci:nightly
 ghcr.io/eic/eic_xl:nightly
+ghcr.io/eic/eic_xl:25.11.2-stable
+ghcr.io/eic/eic_xl:25.07.0-stable
 ghcr.io/eic/eic_cuda:nightly
 ghcr.io/eic/eic_dev_cuda:nightly
 raygunkennesaw/tensorflow:1.2.0-py3


### PR DESCRIPTION
This PR adds two images to the ghcr.io set for the Electron-Ion Collider that we use for backwards compatibility testing in ci jobs against cvmfs (i.e. a smaller set than all versions with a glob).