### PR TITLE
Add valetov/cosy-glyfada image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -512,6 +512,7 @@ valetov/beam_track:*
 
 # Michigan State U, Center for Beam Theory and Dynamical Systems
 valetov/cosy:*
+valetov/cosy-glyfada:*
 valetov/g4bl:*
 valetov/gm2dev:*
 valetov/glyfada:*


### PR DESCRIPTION
Add `valetov/cosy-glyfada` container image for COSY INFINITY + Glyfada multi-objective optimiser.

The image extends `valetov/glyfada` (already synced) with an encrypted COSY INFINITY binary for beam physics optimization on OSG. COSY is GPG-encrypted (AES-256) at rest and decrypted at runtime with a per-job passphrase — the same approach used in the existing `valetov/cosy:10s` image.

Michigan State University, Center for Beam Theory and Dynamical Systems.