### PR TITLE
Add PyCBC 2.11.* images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -270,6 +270,7 @@ pycbc/pycbc-el7:v1.16.12
 pycbc/pycbc-el7:v1.18.3
 pycbc/pycbc-el8:v2.3.*
 pycbc/pycbc-el8:v2.8.*
+pycbc/pycbc-el8:v2.11.*
 pycbc/pycbc-el8:latest
 
 # CMS worker node


### PR DESCRIPTION
PyCBC 2.11 is a release line that will be used for internal LIGO-Virgo-KAGRA analyses like 2.3 and 2.8.