### PR TITLE
Add ewem runtime image for CVMFS publishing

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -449,6 +449,8 @@ containers.ligo.org/karl-wette/lalsuite-containers:7.26.2.15fff1bf87f1bf6b283aad
 containers.ligo.org/karl-wette/lalsuite-containers:7.26.2.e17f0a58054912da8a14a7f87505839783664e63.src-build1
 containers.ligo.org/rodrigo.tenorio/skyhough-post-processing:master
 containers.ligo.org/tessa.carver/pygrb_o3a:latest
+containers.ligo.org/surabhi.sachdev/ewem/runtime:latest
+containers.ligo.org/surabhi.sachdev/ewem/runtime:982d4fd734ca85bf6e6194ddc2af9a3010e7b37b
 atanasi/matlab:v97
 atanasi/darkmatter:latest
 lucarvirgo/tensorflowmatlab:latest


### PR DESCRIPTION
## Summary

Add the ewem runtime container image to `docker_images.txt` so it is synced into CVMFS for OSG / IGWN HTCondor use.

## Images added

- `containers.ligo.org/surabhi.sachdev/ewem/runtime:latest`
- `containers.ligo.org/surabhi.sachdev/ewem/runtime:982d4fd734ca85bf6e6194ddc2af9a3010e7b37b`

## Why

This image is used for the ewem GW+EM workflow runtime. Publishing it to CVMFS makes it available to OSG worker nodes through Apptainer without relying on a home-directory environment.

## Notes

- The SHA-pinned tag is the preferred one for reproducible workflow submissions.
- The `latest` tag is included for convenience and smoke-testing.