### PR TITLE
Add jeffersonlab/japan-moller:nightly

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -635,6 +635,10 @@ jasonkwan/autometa:latest
 # UW-Madison & Reed College -- Gitter Lab, SPRAS project
 # https://hub.docker.com/r/reedcompbio
 reedcompbio/omics-integrator-1:latest
+
+# JLab Parity Simulations and Analysis - JAPAN-MOLLER
+# https://hub.docker.com/r/jeffersonlab/japan-moller
+jeffersonlab/japan-moller:nightly
 reedcompbio/omics-integrator-1:no-conda
 reedcompbio/omics-integrator-2:v2
 reedcompbio/pathlinker:latest


### PR DESCRIPTION
Adds the JAPAN-MOLLER analyzer container image (https://hub.docker.com/r/jeffersonlab/japan-moller) so it is synced to /cvmfs/singularity.opensciencegrid.org/.