### PR TITLE
Add new (temporary) location for LALSuite images

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -439,8 +439,8 @@ hub.opensciencegrid.org/htcondor/hpc-annex-pilot:el8
 hub.opensciencegrid.org/htcondor/hpc-annex-pilot:latest
 
 # LIGO/VIRGO/KAGRA - Software - LALSuite
-containers.ligo.org/lscsoft/lalsuite/debian:7.26
-containers.ligo.org/lscsoft/lalsuite/el:7.26
+# - temporary location, will eventually be replaced by igwn/lalsuite
+kwwette/lalsuite:*
 
 # LIGO/VIRGO/KAGRA - Software - BayesWave
 containers.ligo.org/lscsoft/bayeswave:latest


### PR DESCRIPTION
LALSuite images are now being pushed to DockerHub. Currently a temporary location is used for testing, eventually the images will move to `igwn/lalsuite`.

2 sets of images will be pushed per week (each set has 3 images for different OSs):
- a weekly snapshot image of the latest development version
- a weekly rebuild of the latest release image (to incorporate security updates, etc.)

Occasionally new release images will be pushed, at most a few per year.