### PR TITLE
Added the Fermilab fnal-dev-el9 image

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -399,6 +399,7 @@ fermilab/fnal-wn-el8:*
 fermilab/fnal-wn-sl7:*
 fermilab/fnal-wn-sl6:*
 fermilab/fnal-dev-sl7:*
+fermilab/fnal-dev-el9:*
 fermilab/benchmark:*
 
 # NOvA Experiment


### PR DESCRIPTION
This image is an extension of the EL9 (AlmaLinux 9) worker node, to allow development, for example the building of SPACK packages