### PR TITLE
Add ghcr.io/novaexperiment/nova-claude:latest

### DIFF
--- a/docker_images.txt
+++ b/docker_images.txt
@@ -404,6 +404,7 @@ fermilab/benchmark:*
 
 # NOvA Experiment
 ghcr.io/novaexperiment/el7-tensorflow-gpu:latest
+ghcr.io/novaexperiment/nova-claude:latest
 ghcr.io/novaexperiment/nova-sl7-novat2k:2020-10-27_freeze
 ghcr.io/novaexperiment/nova-sl7-novat2k:aborttest
 ghcr.io/novaexperiment/nova-sl7-novat2k:latest


### PR DESCRIPTION
Please sync one new image for the NOvA experiment:

```
ghcr.io/novaexperiment/nova-claude:latest
```

**What it is.** A sandboxed environment for running AI coding agents on NOvA's shared interactive nodes. The agent runs inside `apptainer exec --containall` with an explicit bind allowlist, so an interactive session cannot reach users' ssh keys, Kerberos credentials, or other users' tokens on the same machine. Distributing it through CVMFS means every user runs the identical reviewed image rather than a local copy they installed and maintain themselves.

**Details**

| | |
|---|---|
| Base | AlmaLinux 9 |
| Size | ~237 MB (SIF) |
| Source | https://github.com/novaexperiment/nova-claude |
| Rebuilt | weekly by GitHub Actions, plus on change |
| Visibility | public — anonymous `apptainer pull` verified working |

**Only `:latest` is requested.** The build publishes a version-pinned tag on each release as well, but those change often and are not worth syncing; on the rare occasion someone needs to pin or roll back, they can pull that tag directly from GHCR.

The image contains apptainer itself, since the NOvA toolchain is reached through a nested SL7 container (`sl7-nova`); that nesting is verified working from the CVMFS-distributed image.